### PR TITLE
Configurable cache path.

### DIFF
--- a/cmd/nnote/root.go
+++ b/cmd/nnote/root.go
@@ -4,8 +4,13 @@ import (
 	"log"
 	"os"
 
+	onenote "github.com/fatihdumanli/onen0te-cli"
 	"github.com/fatihdumanli/onen0te-cli/internal/style"
 	"github.com/spf13/cobra"
+)
+
+var (
+	cachePath string
 )
 
 var rootCmd = &cobra.Command{
@@ -14,7 +19,12 @@ var rootCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 }
 
+func init() {
+	rootCmd.PersistentFlags().StringVarP(&cachePath, "cache", "c", "$HOME/.config/nnote", "Cache path")
+}
+
 func Execute() {
+	onenote.Init(onenote.Options{CachePath: os.ExpandEnv(cachePath)})
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal("\n" + style.Error(err.Error()))
 		os.Exit(1)

--- a/internal/storage/bitcask.go
+++ b/internal/storage/bitcask.go
@@ -8,12 +8,12 @@ import (
 	errors "github.com/pkg/errors"
 )
 
-type Bitcask struct{}
+type Bitcask struct{ Path string }
 
 //Get the value of the given key.
 func (b *Bitcask) Get(key string, obj interface{}) error {
 	//TODO: return an error if the obj is not a ptr type
-	var db, closer, err = openBitcaskDb()
+	var db, closer, err = b.openBitcaskDb()
 	defer closer()
 	if err != nil {
 		return errors.Wrap(err, "couldn't open bitcask db")
@@ -35,7 +35,7 @@ func (b *Bitcask) Get(key string, obj interface{}) error {
 //Save a key-value pair to the local storage
 func (b *Bitcask) Set(key string, val interface{}) error {
 
-	var db, closer, err = openBitcaskDb()
+	var db, closer, err = b.openBitcaskDb()
 	defer closer()
 	if err != nil {
 		return errors.Wrap(err, "couldn't open bitcask db")
@@ -55,7 +55,7 @@ func (b *Bitcask) Set(key string, val interface{}) error {
 
 //Remove the given key
 func (b *Bitcask) Remove(key string) error {
-	var db, closer, err = openBitcaskDb()
+	var db, closer, err = b.openBitcaskDb()
 	defer closer()
 	if err != nil {
 		return errors.Wrap(err, "couldn't open bitcask db")
@@ -74,7 +74,7 @@ func (b *Bitcask) Remove(key string) error {
 }
 
 func (b *Bitcask) GetKeys() (*[]string, error) {
-	var db, closer, err = openBitcaskDb()
+	var db, closer, err = b.openBitcaskDb()
 	var keys []string
 	defer closer()
 	if err != nil {
@@ -90,8 +90,8 @@ func (b *Bitcask) GetKeys() (*[]string, error) {
 	return &keys, nil
 }
 
-func openBitcaskDb() (*bitcask.Bitcask, func() error, error) {
-	db, err := bitcask.Open("/tmp/nnote")
+func (b *Bitcask) openBitcaskDb() (*bitcask.Bitcask, func() error, error) {
+	db, err := bitcask.Open(b.Path)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "couldn't open bitcask db")
 	}

--- a/onenote.go
+++ b/onenote.go
@@ -18,6 +18,10 @@ import (
 	"github.com/pterm/pterm"
 )
 
+type Options struct {
+	CachePath string
+}
+
 type onenote struct {
 	storage     storage.Storer
 	auth        authentication.Authenticator
@@ -353,10 +357,11 @@ func printAliasReminder(section string) {
 	fmt.Println()
 }
 
-//Grab the token from the local storage upon startup
-func init() {
+func Init(options Options) {
+	//Grab the token from the local storage upon startup
 	api := msftgraph.NewApi(&rest.RestClient{}, "https://graph.microsoft.com/v1.0")
-	bitcask := &storage.Bitcask{}
+	// Set path: TODO
+	bitcask := &storage.Bitcask{Path: options.CachePath}
 	root = onenote{api: api, storage: bitcask}
 	root.token = &oauthv2.OAuthToken{}
 	root.oauthClient = oauthv2.NewOAuthClient(&rest.RestClient{})
@@ -366,4 +371,5 @@ func init() {
 		//token does not exist on the local storage
 		root.token = nil
 	}
+
 }

--- a/onenote_test.go
+++ b/onenote_test.go
@@ -13,6 +13,7 @@ type Notebook = msftgraph.Notebook
 type Section = msftgraph.Section
 
 func Test_GetAlias(t *testing.T) {
+	Init(Options{CachePath: "/tmp/onenote_test"})
 	data := []struct {
 		name           string
 		expectedAlias  Alias


### PR DESCRIPTION
Add a command line flag `--cache` that specifies the location of the Bitcask directory. By default, this is `~/.config/nnote`.